### PR TITLE
Drop EOL Python 3.8/3.9, add 3.13 and 3.14 to CI matrices

### DIFF
--- a/.github/workflows/tests-codecheck.yml
+++ b/.github/workflows/tests-codecheck.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, '3.10', 3.11, 3.12]
+        python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,11 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3,):
+if sys.version_info < (3, 10):
     print(
         """You are trying to install beka on python {py}
 
-beka is not compatible with python 2, please upgrade to python 3.8 or newer.""".format(
+beka is not compatible with python earlier than 3.10, please upgrade.""".format(
             py=".".join([str(v) for v in sys.version_info[:3]])
         ),
         file=sys.stderr,
@@ -20,6 +20,6 @@ beka is not compatible with python 2, please upgrade to python 3.8 or newer.""".
 setup(
     name="beka",
     setup_requires=["pbr>=1.9", "setuptools>=17.1"],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     pbr=True,
 )


### PR DESCRIPTION
Python 3.8 reached EOL on 2024-10-07; 3.9 on 2025-10-07. Drop both from the test matrices and bump python_requires to >=3.10. While here, extend coverage with 3.13 and 3.14 to match faucet's supported range.

* tests-unit.yml: matrix 3.9, 3.10, 3.11, 3.12 -> 3.10, 3.11, 3.12, 3.13, 3.14.
* tests-codecheck.yml: pytype matrix 3.8, 3.9, 3.10 -> 3.10, 3.11, 3.12, 3.13, 3.14.
* setup.py: python_requires >=3.8 -> >=3.10; refresh the pre-install version check to match.